### PR TITLE
use cakephp input method to generate datepicker inputs (task #1992)

### DIFF
--- a/src/Template/Element/datepicker.ctp
+++ b/src/Template/Element/datepicker.ctp
@@ -30,7 +30,7 @@ $required = $required ? 'required="required"': '';
         <?= $this->Form->label($fieldName); ?>
     <?php endif; ?>
     <div class='input-group date <?= $type ?>'>
-        <input type="text" class="form-control" name="<?= $fieldName ?>" <?= $required ?> value="<?= $value ?>" />
+        <?= $this->Form->input($fieldName, ['label' => false, 'value' => $value, 'required' => $required]) ?>
         <?php if ($icon) : ?>
             <span class="input-group-addon">
                 <span class="glyphicon glyphicon-<?= $icon ?>"></span>


### PR DESCRIPTION
It handles dot notation for the field names. For example `Posts.title` currently outputs form name:
```html
<input name="Posts.title" />
```

Using CakePHP's input() action outputs:
```html
<input name="Posts[title]" />
```