### PR TITLE
Add red asterisk(*) to required fields (task #2475)

### DIFF
--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -1,11 +1,14 @@
 /* Global custom styles go here */
+.form-group.required .control-label:after {
+   content:"*";
+   color:red;
+}
 .feedback-message {
 	padding-top: 20px;
 }
 .fa-space {
 	margin-right: 5px;
 }
-
 .panel-body form > button {
     margin-top: 10px;
 }


### PR DESCRIPTION
Required form fields will now have a red asterisk displayed
right after the field label.

Thanks to:
http://stackoverflow.com/questions/23141854/adding-asterisk-to-required-fields-in-bootstrap-3